### PR TITLE
Set c++14 as standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LIBRARY_VERSION_MINOR 0)
 set(LIBRARY_VERSION_PATCH 1)
 
 # Set C++ standard
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 # Add your source files
 set(SOURCES


### PR DESCRIPTION
Attempting an install on `Ubuntu 22.04`, with `gcc 8.4.0` and `cmake 3.22.1`.
Within project's root folder, created a `build` directory, moved into it, and ran `cmake ../` (no libtiff location, I just wanted to test if it was possible installing the library without first installing libtiff and providing its location).

That returned:
```
-- The C compiler identification is GNU 8.4.0
-- The CXX compiler identification is GNU 8.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/msalinas/Documents/standalone-installations/EerReaderLib/build
```
So far so good, but then, I ran `make`, which returned the following error:
```
[ 10%] Building CXX object CMakeFiles/EERReaderLib.dir/Bitmap.cpp.o
[ 20%] Building CXX object CMakeFiles/EERReaderLib.dir/DefectMaskingEER.cpp.o
[ 30%] Building CXX object CMakeFiles/EERReaderLib.dir/EerFile.cpp.o
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp: In function ‘void Fei::Acquisition::EerReader::{anonymous}::TagExtender(TIFF*)’:
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
         };
         ^
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp: In member function ‘std::unique_ptr<Fei::Acquisition::EerReader::EerFrame> Fei::Acquisition::EerReader::EerFile::GetNextEerFrame()’:
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:89:29: error: ‘make_unique’ is not a member of ‘std’
             eerFrame = std::make_unique<EerFrame>(m_tiff.get());
                             ^~~~~~~~~~~
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:89:29: note: ‘std::make_unique’ is only available from C++14 onwards
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:89:49: error: expected primary-expression before ‘>’ token
             eerFrame = std::make_unique<EerFrame>(m_tiff.get());
                                                 ^
make[2]: *** [CMakeFiles/EERReaderLib.dir/build.make:104: CMakeFiles/EERReaderLib.dir/EerFile.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:100: CMakeFiles/EERReaderLib.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
There are also some warnings, but, what is really concerning is the error: `'make_unique' is not a member of 'std'`

After a quick search, I found out that such function is included in c++14, and that it can be used from gcc / g++ >= 5 if c++14 is enabled.

After the proposed change, compilation now returns a different error (but completes a greater percentage of the compilation, so there was some progress):
```
[ 10%] Building CXX object CMakeFiles/EERReaderLib.dir/Bitmap.cpp.o
[ 20%] Building CXX object CMakeFiles/EERReaderLib.dir/DefectMaskingEER.cpp.o
[ 30%] Building CXX object CMakeFiles/EERReaderLib.dir/EerFile.cpp.o
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp: In function ‘void Fei::Acquisition::EerReader::{anonymous}::TagExtender(TIFF*)’:
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
         };
         ^
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
/home/msalinas/Documents/standalone-installations/EerReaderLib/EerFile.cpp:53:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
[ 40%] Building CXX object CMakeFiles/EERReaderLib.dir/EerFrame.cpp.o
[ 50%] Building CXX object CMakeFiles/EERReaderLib.dir/ElectronCountedFramesDecompressor.cpp.o
[ 60%] Building CXX object CMakeFiles/EERReaderLib.dir/GainDefectCorrect.cpp.o
[ 70%] Building CXX object CMakeFiles/EERReaderLib.dir/stdafx.cpp.o
In file included from /home/msalinas/Documents/standalone-installations/EerReaderLib/stdafx.h:10,
                 from /home/msalinas/Documents/standalone-installations/EerReaderLib/stdafx.cpp:7:
/home/msalinas/Documents/standalone-installations/EerReaderLib/targetver.h:10:10: fatal error: SDKDDKVer.h: No such file or directory
 #include <SDKDDKVer.h>
          ^~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/EERReaderLib.dir/build.make:160: CMakeFiles/EERReaderLib.dir/stdafx.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:100: CMakeFiles/EERReaderLib.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

So, my idea is to merge this change, and then maybe open an issue to try to figure out what else is missing to complete the installation.